### PR TITLE
Add assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ shadowJar {
     archiveClassifier = null
 }
 
-run{
+run {
     standardInput = System.in
     enableAssertions = true
 }

--- a/src/main/java/thanos/storage/Storage.java
+++ b/src/main/java/thanos/storage/Storage.java
@@ -46,8 +46,10 @@ public class Storage implements IStorage {
      * </p>
      *
      * @param fileName the name of the file to store task data.
+     * @throws AssertionError if the fileName provided is empty and assertions are enabled.
      */
     public Storage(String fileName) {
+        assert !fileName.isEmpty() : "File name must not be empty";
         String filePath = String.format("%s/%s", directoryPath, fileName);
         this.file = new File(filePath);
     }

--- a/src/main/java/thanos/tasks/TaskList.java
+++ b/src/main/java/thanos/tasks/TaskList.java
@@ -33,8 +33,10 @@ public class TaskList {
      * </p>
      *
      * @param storage the {@code IStorage} instance used for loading and saving tasks.
+     * @throws AssertionError if the {@code storage} provided is null and assertions are enabled.
      */
     public TaskList(IStorage storage) {
+        assert storage != null : "Storage provided to TaskList should not be null";
         this.tasks = storage.load();
         this.storage = storage;
     }


### PR DESCRIPTION
The code assumes that the file name provided to Storage is not empty and that the Storage object provided to TaskList is not null.

This can lead to exceptions being thrown, which are hard to debug.

Add assertions to verify that such assumptions are true and to provide informative error messages if such assumptions are false.